### PR TITLE
Update to ActiveSupport 5+

### DIFF
--- a/lib/ruby-app/environment.rb
+++ b/lib/ruby-app/environment.rb
@@ -22,6 +22,10 @@ Bundler.require(:default, App.env.to_sym)
 
 # AS dependencies
 # i prefer 2.seconds, or x.blank? functions by default
+require 'active_support/version'
+if ActiveSupport::VERSION::MAJOR >= 5
+  require 'active_support' 
+end
 require 'active_support/dependencies'
 require 'active_support/core_ext/numeric/time'
 require 'active_support/core_ext/object/blank'


### PR DESCRIPTION
```
require 'active_support/dependencies'
```
It not works for ActiveSupport 5+. See https://github.com/rails/rails/issues/24818